### PR TITLE
Refactor Azure deployment pipeline and production scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ variables:
   imageRepository: 'daily-ninja'
   dockerfilePath: 'docker/Dockerfile.azure'
   azureContainerRegistry: '$(ACR_LOGIN_SERVER)'
+  imageTag: '$(Build.BuildId)'
 
 stages:
 - stage: Build
@@ -69,15 +70,14 @@ stages:
   jobs:
   - job: BuildImage
     steps:
-    - task: Docker@2
-      displayName: Build image
+    - script: |
+        docker build -f $(dockerfilePath) -t $(ACR_LOGIN_SERVER)/$(imageRepository):$(imageTag) .
+        docker save $(ACR_LOGIN_SERVER)/$(imageRepository):$(imageTag) -o $(Build.ArtifactStagingDirectory)/daily-ninja-image.tar
+      displayName: Build and save image artifact
+    - task: PublishBuildArtifacts@1
       inputs:
-        command: build
-        repository: '$(imageRepository)'
-        Dockerfile: '$(dockerfilePath)'
-        tags: |
-          $(Build.BuildId)
-          latest
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)/daily-ninja-image.tar'
+        ArtifactName: 'docker-image'
 
 - stage: Push
   displayName: Push
@@ -86,25 +86,28 @@ stages:
   jobs:
   - job: PushImage
     steps:
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: current
+        downloadType: single
+        artifactName: docker-image
+        downloadPath: '$(Pipeline.Workspace)'
     - task: Docker@2
       displayName: Login to ACR
       inputs:
         command: login
         containerRegistry: '$(ACR_SERVICE_CONNECTION)'
-    - task: Docker@2
-      displayName: Push image
-      inputs:
-        command: push
-        containerRegistry: '$(ACR_SERVICE_CONNECTION)'
-        repository: '$(imageRepository)'
-        tags: |
-          $(Build.BuildId)
-          latest
+    - script: |
+        docker load -i $(Pipeline.Workspace)/docker-image/daily-ninja-image.tar
+        docker push $(ACR_LOGIN_SERVER)/$(imageRepository):$(imageTag)
+        docker tag $(ACR_LOGIN_SERVER)/$(imageRepository):$(imageTag) $(ACR_LOGIN_SERVER)/$(imageRepository):latest
+        docker push $(ACR_LOGIN_SERVER)/$(imageRepository):latest
+      displayName: Load and push image
 
 - stage: Deploy
   displayName: Deploy
   dependsOn: Push
-  condition: succeeded()
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   jobs:
   - deployment: DeployWebApp
     environment: production
@@ -122,7 +125,7 @@ stages:
                 az webapp config container set \
                   --resource-group $(AZURE_RESOURCE_GROUP) \
                   --name $(AZURE_WEBAPP_NAME) \
-                  --container-image-name $(ACR_LOGIN_SERVER)/$(imageRepository):$(Build.BuildId) \
+                  --container-image-name $(ACR_LOGIN_SERVER)/$(imageRepository):$(imageTag) \
                   --container-registry-url https://$(ACR_LOGIN_SERVER)
 
                 az webapp config appsettings set \
@@ -135,3 +138,7 @@ stages:
                     SECRET_KEY='@Microsoft.KeyVault(SecretUri=$(KV_SECRET_KEY_URI))' \
                     JWT_SECRET_KEY='@Microsoft.KeyVault(SecretUri=$(KV_JWT_SECRET_KEY_URI))' \
                     DATABASE_URL='@Microsoft.KeyVault(SecretUri=$(KV_DATABASE_URL_URI))'
+
+                az webapp restart \
+                  --resource-group $(AZURE_RESOURCE_GROUP) \
+                  --name $(AZURE_WEBAPP_NAME)

--- a/docs/AZURE_DEPLOY.md
+++ b/docs/AZURE_DEPLOY.md
@@ -145,3 +145,22 @@ If Key Vault references are used, confirm app identity access:
 az webapp identity show --resource-group $AZURE_RESOURCE_GROUP --name daily-ninja-app
 az keyvault show --name daily-ninja-kv --query properties.vaultUri -o tsv
 ```
+
+## Reviewer checklist for this PR
+
+Run these commands from repo root:
+
+```bash
+bash scripts/azure/01_setup_rg_acr.sh
+bash scripts/azure/02_build_push.sh
+bash scripts/azure/03_deploy_webapp.sh
+bash scripts/azure/05_configure_autoscale.sh
+bash scripts/azure/04_verify_deployment.sh
+```
+
+Then confirm:
+
+```bash
+curl -fsS https://daily-ninja-app.azurewebsites.net/health
+python -m pytest daily_ninja_python/tests/integration/test_post_deploy.py -q
+```

--- a/scripts/azure/01_setup_rg_acr.sh
+++ b/scripts/azure/01_setup_rg_acr.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 : "${ACR_NAME:=dailyninjaacr}"
 
 az login
-az group create --name "$AZURE_RESOURCE_GROUP" --location "$AZURE_LOCATION"
-az acr create --resource-group "$AZURE_RESOURCE_GROUP" --name "$ACR_NAME" --sku Basic
-az acr show --name "$ACR_NAME" --query loginServer -o tsv
+az group create --name "$AZURE_RESOURCE_GROUP" --location "$AZURE_LOCATION" --output table
+
+if ! az acr show --name "$ACR_NAME" --resource-group "$AZURE_RESOURCE_GROUP" >/dev/null 2>&1; then
+	az acr create --resource-group "$AZURE_RESOURCE_GROUP" --name "$ACR_NAME" --sku Basic --output table
+else
+	echo "ACR $ACR_NAME already exists in $AZURE_RESOURCE_GROUP"
+fi
+
+az acr show --name "$ACR_NAME" --resource-group "$AZURE_RESOURCE_GROUP" --query "{name:name,loginServer:loginServer,sku:sku.name}" --output table

--- a/scripts/azure/03_deploy_webapp.sh
+++ b/scripts/azure/03_deploy_webapp.sh
@@ -11,9 +11,11 @@ set -euo pipefail
 : "${KEY_VAULT_SECRET_KEY_URI:=https://daily-ninja-kv.vault.azure.net/secrets/SECRET_KEY/}"
 : "${KEY_VAULT_JWT_SECRET_KEY_URI:=https://daily-ninja-kv.vault.azure.net/secrets/JWT_SECRET_KEY/}"
 : "${KEY_VAULT_DATABASE_URL_URI:=https://daily-ninja-kv.vault.azure.net/secrets/DATABASE_URL/}"
+: "${KEY_VAULT_NAME:=daily-ninja-kv}"
 : "${APPLICATIONINSIGHTS_CONNECTION_STRING:=}"
 
 ACR_LOGIN_SERVER=$(az acr show --name "$ACR_NAME" --resource-group "$AZURE_RESOURCE_GROUP" --query loginServer -o tsv)
+ACR_ID=$(az acr show --name "$ACR_NAME" --resource-group "$AZURE_RESOURCE_GROUP" --query id -o tsv)
 
 az appservice plan create \
   --name "$APP_SERVICE_PLAN" \
@@ -27,6 +29,22 @@ az webapp create \
   --plan "$APP_SERVICE_PLAN" \
   --name "$AZURE_WEBAPP_NAME" \
   --deployment-container-image-name "$ACR_LOGIN_SERVER/$IMAGE_NAME:$IMAGE_TAG"
+
+az webapp identity assign \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --name "$AZURE_WEBAPP_NAME" >/dev/null
+
+WEBAPP_PRINCIPAL_ID=$(az webapp identity show --resource-group "$AZURE_RESOURCE_GROUP" --name "$AZURE_WEBAPP_NAME" --query principalId -o tsv)
+az role assignment create \
+  --assignee-object-id "$WEBAPP_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --scope "$ACR_ID" \
+  --role AcrPull >/dev/null || true
+
+az keyvault set-policy \
+  --name "$KEY_VAULT_NAME" \
+  --object-id "$WEBAPP_PRINCIPAL_ID" \
+  --secret-permissions get list >/dev/null || true
 
 az webapp config container set \
   --resource-group "$AZURE_RESOURCE_GROUP" \

--- a/scripts/azure/04_verify_deployment.sh
+++ b/scripts/azure/04_verify_deployment.sh
@@ -2,8 +2,21 @@
 set -euo pipefail
 
 : "${DEPLOYED_URL:=https://daily-ninja-app.azurewebsites.net}"
+: "${AZURE_RESOURCE_GROUP:=daily-ninja-rg}"
+: "${AZURE_WEBAPP_NAME:=daily-ninja-app}"
+: "${ACR_NAME:=dailyninjaacr}"
 
-curl -fsS "$DEPLOYED_URL/health"
+if ! curl -fsS "$DEPLOYED_URL/health"; then
+	echo "Health check failed for $DEPLOYED_URL"
+	echo "Run troubleshooting:"
+	echo "az webapp show --resource-group $AZURE_RESOURCE_GROUP --name $AZURE_WEBAPP_NAME --query defaultHostName -o tsv"
+	echo "az webapp config container show --resource-group $AZURE_RESOURCE_GROUP --name $AZURE_WEBAPP_NAME"
+	echo "az webapp config appsettings list --resource-group $AZURE_RESOURCE_GROUP --name $AZURE_WEBAPP_NAME"
+	echo "az webapp log tail --name $AZURE_WEBAPP_NAME --resource-group $AZURE_RESOURCE_GROUP"
+	echo "az acr repository list --name $ACR_NAME -o table"
+	exit 1
+fi
+
 curl -fsS "$DEPLOYED_URL/"
 
 export DAILY_NINJA_BASE_URL="$DEPLOYED_URL"


### PR DESCRIPTION
## What was refactored
- Audited and tightened Azure deployment assets across Docker, pipeline, scripts, and docs.
- Hardened scripts/azure/01_setup_rg_acr.sh for idempotent RG/ACR setup and clearer outputs.
- Hardened scripts/azure/03_deploy_webapp.sh with:
  - system-assigned identity assignment
  - ACR AcrPull role assignment
  - Key Vault access policy for secret retrieval
  - explicit app settings for Key Vault references and App Insights connection string
- Improved scripts/azure/04_verify_deployment.sh to emit actionable troubleshooting commands when deployment is unreachable.

## CI/CD structure
Pipeline in azure-pipelines.yml now follows:
1. Build
2. Test (lint + pytest + unittest + coverage publish)
3. DockerBuild (build image and save as artifact)
4. Push (download/load artifact, ACR login, push image + latest tag)
5. Deploy (main branch only, set Web App container + app settings)

This fixes cross-stage image availability by passing a docker image artifact from DockerBuild to Push.

## Deployment scripts and verification tests
- Azure scripts are in scripts/azure/:
  - 01_setup_rg_acr.sh
  - 02_build_push.sh
  - 03_deploy_webapp.sh
  - 04_verify_deployment.sh
  - 05_configure_autoscale.sh
- Post-deploy integration tests are in daily_ninja_python/tests/integration/test_post_deploy.py and validate:
  - /health
  - /
  - /tasks auth behavior

## Environment variable validation and Web App wiring
- .env.example values are consumed in backend config/runtime and deployment scripts.
- Production-required vars are validated in backend config (SECRET_KEY, JWT_SECRET_KEY, DATABASE_URL).
- Azure Web App appsettings use Key Vault references and App Insights connection string.

## Reviewer instructions
Run these from repo root:
`ash
bash scripts/azure/01_setup_rg_acr.sh
bash scripts/azure/02_build_push.sh
bash scripts/azure/03_deploy_webapp.sh
bash scripts/azure/05_configure_autoscale.sh
bash scripts/azure/04_verify_deployment.sh
`
Then verify:
`ash
curl -fsS https://daily-ninja-app.azurewebsites.net/health
python -m pytest daily_ninja_python/tests/integration/test_post_deploy.py -q
`
If unreachable, follow troubleshooting in docs/AZURE_DEPLOY.md (logs, container config, appsettings, ACR tags, identity/Key Vault checks).