### PR TITLE
Add unit tests for streak counter and heatmap tracker

### DIFF
--- a/daily_ninja_python/backend/app/core/__init__.py
+++ b/daily_ninja_python/backend/app/core/__init__.py
@@ -1,4 +1,4 @@
 """Core Configuration"""
-from .config import config, Config
+from .config import config, Config, validate_required_env
 
-__all__ = ["config", "Config"]
+__all__ = ["config", "Config", "validate_required_env"]

--- a/daily_ninja_python/frontend/app.py
+++ b/daily_ninja_python/frontend/app.py
@@ -155,6 +155,15 @@ def get_monthly_stats():
     active_days = sum(1 for d in month_dates if data["activity"].get(d, 0) > 0)
     return {"tasks": tasks_done, "active_days": active_days, "missed": 30 - active_days}
 
+
+def get_missed_days_alert(missed_days):
+    """Return alert level/message for weekly missed days."""
+    if missed_days > 2:
+        return "warning", f"⚠️ You missed {missed_days} days this week. Keep that streak going!"
+    if missed_days == 0:
+        return "success", "🎉 Perfect week! You logged activity every day!"
+    return None, None
+
 def get_earned_badges(streak):
     """Get list of badges with earned/locked status."""
     return [{"badge": b, "earned": streak >= b["days"]} for b in BADGES]
@@ -341,10 +350,11 @@ def main():
         st.bar_chart({d["day"]: d["tasks"] for d in week_data})
         
         # Missed days alert
-        if weekly["missed"] > 2:
-            st.warning(f"⚠️ You missed {weekly['missed']} days this week. Keep that streak going!")
-        elif weekly["missed"] == 0:
-            st.success("🎉 Perfect week! You logged activity every day!")
+        alert_kind, alert_message = get_missed_days_alert(weekly["missed"])
+        if alert_kind == "warning":
+            st.warning(alert_message)
+        elif alert_kind == "success":
+            st.success(alert_message)
     
     # ===== HEATMAP TAB =====
     with tab3:

--- a/daily_ninja_python/tests/unit/test_heatmap_and_alerts.py
+++ b/daily_ninja_python/tests/unit/test_heatmap_and_alerts.py
@@ -1,0 +1,107 @@
+import importlib.util
+import sys
+import types
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+
+def _load_frontend_app_module(monkeypatch):
+    captured_markdown = []
+
+    st = types.ModuleType("streamlit")
+    st.session_state = types.SimpleNamespace()
+
+    def set_page_config(**_kwargs):
+        return None
+
+    def markdown(text, **_kwargs):
+        captured_markdown.append(text)
+
+    st.set_page_config = set_page_config
+    st.markdown = markdown
+
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    module_path = Path(__file__).resolve().parents[2] / "frontend" / "app.py"
+    spec = importlib.util.spec_from_file_location("frontend_app_for_tests", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    return module, st, captured_markdown
+
+
+def _freeze_now(monkeypatch, module, target_datetime):
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls):
+            return target_datetime
+
+    monkeypatch.setattr(module, "datetime", FixedDateTime)
+
+
+def test_heatmap_render_uses_mock_activity_data(monkeypatch):
+    module, st, captured = _load_frontend_app_module(monkeypatch)
+    today = datetime(2026, 3, 10)
+    _freeze_now(monkeypatch, module, today)
+
+    st.session_state.data = {
+        "todos": [],
+        "streak": 0,
+        "last_date": None,
+        "longest_streak": 0,
+        "activity": {
+            today.strftime("%Y-%m-%d"): 7,
+            (today - timedelta(days=1)).strftime("%Y-%m-%d"): 3,
+        },
+    }
+
+    module.render_heatmap()
+
+    html = captured[-1]
+    assert 'class="heatmap"' in html
+    assert "#39d353" in html  # high contribution color
+    assert "#006d32" in html  # medium contribution color
+
+
+def test_weekly_stats_reports_missed_days(monkeypatch):
+    module, st, _ = _load_frontend_app_module(monkeypatch)
+    today = datetime(2026, 3, 10)
+    _freeze_now(monkeypatch, module, today)
+
+    active_dates = [
+        today.strftime("%Y-%m-%d"),
+        (today - timedelta(days=1)).strftime("%Y-%m-%d"),
+        (today - timedelta(days=3)).strftime("%Y-%m-%d"),
+        (today - timedelta(days=6)).strftime("%Y-%m-%d"),
+    ]
+
+    st.session_state.data = {
+        "activity": {d: 1 for d in active_dates},
+        "todos": [],
+        "streak": 0,
+        "last_date": None,
+        "longest_streak": 0,
+    }
+
+    weekly = module.get_weekly_stats()
+    assert weekly["active_days"] == 4
+    assert weekly["missed"] == 3
+
+
+def test_alert_triggers_for_missed_days(monkeypatch):
+    module, _, _ = _load_frontend_app_module(monkeypatch)
+
+    kind, message = module.get_missed_days_alert(3)
+    assert kind == "warning"
+    assert "missed 3 days" in message
+
+    kind, message = module.get_missed_days_alert(0)
+    assert kind == "success"
+    assert "Perfect week" in message
+
+    kind, message = module.get_missed_days_alert(1)
+    assert kind is None
+    assert message is None

--- a/daily_ninja_python/tests/unit/test_streak_counter.py
+++ b/daily_ninja_python/tests/unit/test_streak_counter.py
@@ -1,0 +1,107 @@
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+# Ensure backend package imports resolve in tests
+BACKEND_ROOT = Path(__file__).resolve().parents[2] / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from run import create_app  # noqa: E402
+from app.models import db, User, Activity  # noqa: E402
+from app.api import tasks as tasks_api  # noqa: E402
+
+
+@pytest.fixture()
+def app():
+    app = create_app("testing")
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    yield app
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def user_id(app):
+    with app.app_context():
+        user = User(email="unit@example.com", username="unit-user")
+        user.set_password("password123")
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def _freeze_today(monkeypatch, target_date):
+    class FixedDate(date):
+        @classmethod
+        def today(cls):
+            return target_date
+
+    monkeypatch.setattr(tasks_api, "date", FixedDate)
+
+
+def test_zero_streak_for_new_user(app, user_id):
+    with app.app_context():
+        user = db.session.get(User, user_id)
+        assert user.current_streak == 0
+        assert user.longest_streak == 0
+
+
+def test_long_streak_increments_on_consecutive_days(app, user_id, monkeypatch):
+    start = date(2026, 1, 1)
+
+    with app.app_context():
+        for offset in range(10):
+            _freeze_today(monkeypatch, start + timedelta(days=offset))
+            tasks_api.log_task_completion(user_id)
+
+        user = db.session.get(User, user_id)
+        assert user.current_streak == 10
+        assert user.longest_streak == 10
+
+        activities = Activity.query.filter_by(user_id=user_id).all()
+        assert len(activities) == 10
+
+
+def test_broken_streak_resets_to_one(app, user_id, monkeypatch):
+    today = date(2026, 2, 10)
+
+    with app.app_context():
+        user = db.session.get(User, user_id)
+        user.current_streak = 7
+        user.longest_streak = 7
+        user.last_activity_date = today - timedelta(days=3)
+        db.session.commit()
+
+        _freeze_today(monkeypatch, today)
+        tasks_api.log_task_completion(user_id)
+
+        db.session.refresh(user)
+        assert user.current_streak == 1
+        assert user.longest_streak == 7
+
+
+def test_same_day_completion_increments_heatmap_not_streak(app, user_id, monkeypatch):
+    today = date(2026, 2, 11)
+
+    with app.app_context():
+        user = db.session.get(User, user_id)
+        user.current_streak = 4
+        user.longest_streak = 5
+        user.last_activity_date = today
+        db.session.commit()
+
+        _freeze_today(monkeypatch, today)
+        first_count = tasks_api.log_task_completion(user_id)
+        second_count = tasks_api.log_task_completion(user_id)
+
+        db.session.refresh(user)
+        assert first_count == 1
+        assert second_count == 2
+        assert user.current_streak == 4
+        assert user.longest_streak == 5


### PR DESCRIPTION
This PR adds pytest-based unit tests for streak counter and heatmap tracker, covering edge cases and alert logic. Improves reproducibility and CI coverage.